### PR TITLE
Remove needless check

### DIFF
--- a/src/ZeffMu/App.php
+++ b/src/ZeffMu/App.php
@@ -81,10 +81,6 @@ class App extends ZfApplication
 
         $configuration = ArrayUtils::merge($defaults, $configuration);
 
-        if (!isset($configuration['modules'])) {
-            $configuration['modules'] = array();
-        }
-
         $configuration['modules'][] = 'ZeffMu';
 
         return parent::init($configuration);


### PR DESCRIPTION
`$configuration['modules']` is already defined in line [78](https://github.com/danizord/ZeffMu/blob/f466cd3d6124eeec646ed76898b6a1df51928544/src/ZeffMu/App.php#L78).
