### PR TITLE
Added in missing zend framework components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,15 @@
     "require": {
         "php": ">=5.3",
         "zendframework/zend-mvc": "2.*",
-	"zendframework/zend-form": "2.*"
+        "zendframework/zend-form": "2.*",
+        "zendframework/zend-modulemanager": "2.*",
+        "zendframework/zend-loader": "2.*",
+        "zendframework/zend-view": "2.*",
+        "zendframework/zend-serializer": "2.*",
+        "zendframework/zend-log": "2.*",
+        "zendframework/zend-i18n": "2.*",
+        "zendframework/zend-console": "2.*",
+        "zendframework/zend-http": "2.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I attempted to use the package as-is and encountered a series of missing class exceptions. So after working through each of them, I've added them to composer.json so that the package works "out of the box".